### PR TITLE
Fix pointer overflow in keyboard init

### DIFF
--- a/StardewValley.Patches.mm/Framework/PatchHelper.cs
+++ b/StardewValley.Patches.mm/Framework/PatchHelper.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Reflection;
+
+namespace StardewValley.Patches.mm.Framework
+{
+    /// <summary>Provides utility methods to simplify patches.</summary>
+    internal static class PatchHelper
+    {
+        /*********
+        ** Fields
+        *********/
+        /// <summary>Binding flags which match all members.</summary>
+        private const BindingFlags All = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static;
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Get an event and assert that it's present.</summary>
+        /// <param name="type">The type whose members to search.</param>
+        /// <param name="name">The event name.</param>
+        public static EventInfo RequireEvent(Type type, string name)
+        {
+            return type.GetEvent(name, PatchHelper.All) ?? throw new InvalidOperationException($"Can't find event '{name}' on {type.FullName}");
+        }
+
+        /// <summary>Get a field and assert that it's present.</summary>
+        /// <param name="type">The type whose members to search.</param>
+        /// <param name="name">The field name.</param>
+        public static FieldInfo RequireField(Type type, string name)
+        {
+            return type.GetField(name, PatchHelper.All) ?? throw new InvalidOperationException($"Can't find field '{name}' on {type.FullName}");
+        }
+
+        /// <summary>Get a method from the underlying <see cref="KeyboardInput"/> and assert that it's present.</summary>
+        /// <param name="type">The type whose members to search.</param>
+        /// <param name="name">The method name.</param>
+        public static MethodInfo RequireMethod(Type type, string name)
+        {
+            return type.GetMethod(name, PatchHelper.All) ?? throw new InvalidOperationException($"Can't find method '{name}' on {type.FullName}");
+        }
+
+        /// <summary>Get a nested type from the underlying <see cref="KeyboardInput"/> and assert that it's present.</summary>
+        /// <param name="type">The type whose members to search.</param>
+        /// <param name="name">The nested type name.</param>
+        public static Type RequireNestedType(Type type, string name)
+        {
+            return type.GetNestedType(name, PatchHelper.All) ?? throw new InvalidOperationException($"Can't find nested type '{name}' on {type.FullName}");
+        }
+    }
+}

--- a/StardewValley.Patches.mm/patch_KeyboardDispatcher.cs
+++ b/StardewValley.Patches.mm/patch_KeyboardDispatcher.cs
@@ -6,6 +6,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using MonoMod;
 using MonoMod.Utils;
+using StardewValley.Patches.mm.Framework;
 
 // ReSharper disable once CheckNamespace
 namespace StardewValley
@@ -14,15 +15,6 @@ namespace StardewValley
     [SuppressMessage("Style", "IDE1006:Naming Styles")]
     class patch_KeyboardDispatcher : KeyboardDispatcher
     {
-        [SuppressMessage("Style", "IDE1006:Naming Styles")]
-        public extern void orig_ctor(GameWindow window);
-
-        // ReSharper disable once ArrangeTypeMemberModifiers
-        const BindingFlags all = BindingFlags.NonPublic
-                                    | BindingFlags.Public
-                                    | BindingFlags.Instance
-                                    | BindingFlags.Static;
-
         [MonoModConstructor]
         [SuppressMessage("Style", "IDE1006:Naming Styles")]
         public void ctor(GameWindow window)
@@ -36,7 +28,7 @@ namespace StardewValley
 
             // https://stackoverflow.com/questions/1121441/addeventhandler-using-reflection
             // https://stackoverflow.com/questions/11120401/creating-delegate-from-methodinfo
-            EventInfo windowTextInput = typeof(GameWindow).GetEvent("TextInput", all);
+            EventInfo windowTextInput = PatchHelper.RequireEvent(typeof(GameWindow), "TextInput");
             Delegate handler = Delegate.CreateDelegate(windowTextInput.EventHandlerType, this, "Event_TextInput");
             windowTextInput.AddEventHandler(window, handler);
 

--- a/StardewValley.Patches.mm/patch_KeyboardInput.cs
+++ b/StardewValley.Patches.mm/patch_KeyboardInput.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using StardewValley.Patches.mm.Framework;
+
+// ReSharper disable once CheckNamespace
+namespace StardewValley
+{
+    /// <summary>A MonoMod patch that swaps 'SetWindowLong' (which is 32-bit only) to 'SetWindowLongPtr'.</summary>
+    static class patch_KeyboardInput
+    {
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+        [DllImport("Imm32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr ImmGetContext(IntPtr hWnd);
+
+        public static void Initialize(GameWindow window)
+        {
+            // fetch private members
+            Type type = typeof(KeyboardInput);
+            FieldInfo initialized = PatchHelper.RequireField(type, "initialized");
+            FieldInfo prevWndProc = PatchHelper.RequireField(type, "prevWndProc");
+            FieldInfo hookProcDelegate = PatchHelper.RequireField(type, "hookProcDelegate");
+            FieldInfo himc = PatchHelper.RequireField(type, "hIMC");
+            Delegate hookProc = Delegate.CreateDelegate(type: PatchHelper.RequireNestedType(type, "WndProc"), firstArgument: null, method: PatchHelper.RequireMethod(type, "HookProc"), throwOnBindFailure: true);
+
+            // replicate game logic, but swap out SetWindowLong
+            if ((bool)initialized.GetValue(null))
+                throw new InvalidOperationException("TextInput.Initialize can only be called once!");
+            hookProcDelegate.SetValue(null, hookProc);
+            prevWndProc.SetValue(null, (IntPtr)SetWindowLongPtr(window.Handle, -4, Marshal.GetFunctionPointerForDelegate((Delegate)hookProcDelegate.GetValue(null))));
+            himc.SetValue(null, ImmGetContext(window.Handle));
+            initialized.SetValue(null, true);
+        }
+    }
+}


### PR DESCRIPTION
`KeyboardInput` casts addresses to int when initializing, which causes an arithmetic overflow if they're outside the 32-bit range. This commit replaces `SetWindowLong` (which is 32-bit only) with `SetWindowLongPtr` to avoid that.