### PR TITLE
Replace manual sleeps with checked operations

### DIFF
--- a/SDV.Installer/Framework/FileUtilities.cs
+++ b/SDV.Installer/Framework/FileUtilities.cs
@@ -1,0 +1,36 @@
+﻿using System.IO;
+using System.Threading;
+
+namespace SDV.Installer.Framework
+{
+    /// <summary>Provides utility methods for file operations.</summary>
+    internal static class FileUtilities
+    {
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Copy a file and wait until the copy operation completes.</summary>
+        /// <param name="file">The file to copy.</param>
+        /// <param name="toPath">The absolute destination file path.</param>
+        public static void CopyToAndWait(this FileInfo file, string toPath)
+        {
+            file.CopyTo(toPath, overwrite: true);
+            while (!File.Exists(toPath))
+                Thread.Sleep(100);
+        }
+
+        /// <summary>Delete a file and wait until the deletion completes.</summary>
+        /// <param name="file">The file to copy.</param>
+        /// <returns>Returns whether the file existed and was deleted.</returns>
+        public static bool DeleteAndWait(this FileInfo file)
+        {
+            if (!file.Exists)
+                return false;
+
+            file.Delete();
+            while (File.Exists(file.FullName))
+                Thread.Sleep(100);
+            return true;
+        }
+    }
+}

--- a/SDV.Installer/Program.cs
+++ b/SDV.Installer/Program.cs
@@ -1,37 +1,40 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Threading;
+using SDV.Installer.Framework;
 
 namespace SDV.Installer
 {
     public static class Program
     {
+        /*********
+        ** Fields
+        *********/
         private static readonly string ExePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
         private static readonly string CopyToGameFolderPath = Path.Combine(ExePath, "libs", "CopyToGameFolder");
 
-        private static readonly string[] DirtyFiles = {
-            "MONOMODDED_StardewValley.exe",
-            "MONOMODDED_StardewValley.pdb",
-            "StardewValley.exe"
-        };
-
-        private const string CorFlagsArgs = "/C libs\\CorFlags.exe MONOMODDED_StardewValley.exe /32BITREQ-";
-        private const string MonoModArgs = "/C MonoMod.exe StardewValley.exe";
         private const string ExeName = "StardewValley.exe";
         private const string ModifiedExeName = "MONOMODDED_" + ExeName;
 
-        private static void Main()
+        private static readonly string[] DirtyFiles = {
+            ExeName,
+            ModifiedExeName,
+            "MONOMODDED_StardewValley.pdb",
+        };
+
+        /*********
+        ** Public methods
+        *********/
+        public static void Main()
         {
             Console.WriteLine("Cleaning out any potentially dirty files...");
 
-            foreach (string file in DirtyFiles.Where(file => File.Exists(Path.Combine(ExePath, file))))
+            foreach (string fileName in DirtyFiles)
             {
-                File.Delete(Path.Combine(ExePath, file));
-                Console.WriteLine($"Deleted {file}!");
+                FileInfo file = new FileInfo(Path.Combine(ExePath, fileName));
+                if (file.DeleteAndWait())
+                    Console.WriteLine($"Deleted {fileName}!");
             }
 
             for (int i = 0; i < 2; i++)
@@ -44,6 +47,10 @@ namespace SDV.Installer
             Prompt();
         }
 
+
+        /*********
+        ** Private methods
+        *********/
         private static void Prompt()
         {
             string option = WriteReadLine(" [1] I don't have a copy of the Linux version!" +
@@ -90,7 +97,7 @@ namespace SDV.Installer
             ApplyMonoModPatches(installationFolder);
 
             Console.WriteLine();
-            WriteReadKey(" Installation complete! Please launch StardewValley.exe from the depot-download folder!" +
+            WriteReadKey($" Installation complete! Please launch {ExeName} from the depot-download folder!" +
                          "\n Press any key to exit...");
         }
 
@@ -100,25 +107,21 @@ namespace SDV.Installer
             return Console.ReadLine();
         }
 
-        // ReSharper disable once UnusedMethodReturnValue.Local
-        private static string WriteReadKey(string value)
+        private static void WriteReadKey(string value)
         {
             Console.WriteLine(value);
-            return Console.ReadKey().Key.ToString();
+            Console.ReadKey();
         }
 
         private static void CopyRequiredDlls(string installPath)
         {
             Console.WriteLine("Copying required DLLs over to the installation location:");
 
-            List<string> waitForFiles = new List<string>();
-
             // copy game DLLs into execution folder
             foreach (FileInfo dll in new DirectoryInfo(installPath).GetFiles("*.dll"))
             {
                 Console.WriteLine($" Copying {dll.Name} -> exec directory...");
-                File.Copy(dll.FullName, Path.Combine(ExePath, dll.Name), true);
-                waitForFiles.Add(Path.Combine(ExePath, dll.Name));
+                dll.CopyToAndWait(Path.Combine(ExePath, dll.Name));
             }
 
             // copy files into game folder
@@ -130,12 +133,10 @@ namespace SDV.Installer
                 {
                     // TODO: Remove exec step
                     Console.WriteLine($" Copying {dllName} -> exec directory...");
-                    File.Copy(dll.FullName, Path.Combine(ExePath, dllName), true);
-                    waitForFiles.Add(Path.Combine(ExePath, dllName));
+                    dll.CopyToAndWait(Path.Combine(ExePath, dllName));
 
                     Console.WriteLine($" Copying {dllName} -> SDV directory...");
-                    File.Copy(dll.FullName, Path.Combine(installPath, dllName), true);
-                    waitForFiles.Add(Path.Combine(installPath, dllName));
+                    dll.CopyToAndWait(Path.Combine(installPath, dllName));
                 }
                 catch (DirectoryNotFoundException e)
                 {
@@ -145,23 +146,17 @@ namespace SDV.Installer
                 }
             }
 
-            // Is this separate loop required for waiting until all DLLs are copied?
-            foreach (string path in waitForFiles)
-            {
-                while (!File.Exists(path))
-                    Console.ReadLine();
-            }
-
             Console.WriteLine();
         }
 
         private static void ApplyMonoModPatches(string installPath)
         {
-            Console.WriteLine("Copying over StardewValley.exe to patch...");
+            Console.WriteLine($"Copying over {ExeName} to patch...");
 
             try
             {
-                File.Copy(Path.Combine(installPath, ExeName), Path.Combine(ExePath, ExeName), true);
+                FileInfo file = new FileInfo(Path.Combine(installPath, ExeName));
+                file.CopyToAndWait(Path.Combine(ExePath, ExeName));
             }
             catch (FileNotFoundException e)
             {
@@ -170,41 +165,22 @@ namespace SDV.Installer
                 Continue();
             }
 
-            while (!File.Exists(Path.Combine(ExePath, ExeName)))
-                Console.ReadLine();
-
             Console.WriteLine("Applying MonoMod patches...");
 
-            new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "cmd.exe",
-                    Arguments = MonoModArgs
-                }
-            }.Start();
+            RunCommand($"MonoMod.exe {ExeName}");
 
             while (true)
             {
                 try
                 {
-                    // Give it some time, honestly
-                    Thread.Sleep(1000 * 10);
-                    Console.WriteLine("Modifying MONOMODDED_StardewValley.exe flags with CorFlags...\n(If this does not work, please re-launch with administrator privileges)");
+                    Console.WriteLine($"Modifying {ModifiedExeName} flags with CorFlags...\n(If this does not work, please re-launch with administrator privileges)");
 
-                    new Process
-                    {
-                        StartInfo = new ProcessStartInfo
-                        {
-                            WindowStyle = ProcessWindowStyle.Hidden,
-                            FileName = "cmd.exe",
-                            Arguments = CorFlagsArgs
-                        }
-                    }.Start();
+                    RunCommand($"libs\\CorFlags.exe {ModifiedExeName} /32BITREQ-");
 
-                    Thread.Sleep(1000 * 5);
                     Console.WriteLine("Copying the modified EXE over to the installation location...");
-                    File.Copy(Path.Combine(ExePath, ModifiedExeName), Path.Combine(installPath, ExeName), true);
+
+                    var file = new FileInfo(Path.Combine(ExePath, ModifiedExeName));
+                    file.CopyToAndWait(Path.Combine(installPath, ExeName));
                     break;
                 }
                 catch (FileNotFoundException)
@@ -214,6 +190,34 @@ namespace SDV.Installer
             }
 
             Console.WriteLine("Copied the modified EXE over to the installation location!");
+        }
+
+        /// <summary>Run a command through <c>cmd.exe</c> and wait for it to finish.</summary>
+        /// <param name="command">The command to run.</param>
+        private static void RunCommand(string command)
+        {
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+
+            try
+            {
+                var process = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = "cmd.exe",
+                        Arguments = $"/C {command}",
+
+                        // run within the same window
+                        UseShellExecute = false
+                    }
+                };
+                process.Start();
+                process.WaitForExit();
+            }
+            finally
+            {
+                Console.ResetColor();
+            }
         }
     }
 }


### PR DESCRIPTION
With this pull request:
* The installer now waits automatically for the operation to finish when copying/deleting files or running processes. That simplifies the main code and makes the installer much faster, since we don't need to sleep manually.
* Processes now run in the same window, so it's easier to troubleshoot if a process fails.