### PR TITLE
Use temporary staging folder

### DIFF
--- a/SDV.Installer/Framework/FileUtilities.cs
+++ b/SDV.Installer/Framework/FileUtilities.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading;
 
 namespace SDV.Installer.Framework
@@ -31,6 +32,37 @@ namespace SDV.Installer.Framework
             while (File.Exists(file.FullName))
                 Thread.Sleep(100);
             return true;
+        }
+
+        /// <summary>Recursively copy a directory and wait until the copy operation complete.</summary>
+        /// <param name="source">The file or folder to copy.</param>
+        /// <param name="toPath">The absolute destination folder path.</param>
+        public static void RecursiveCopyTo(this DirectoryInfo source, string toPath)
+        {
+            // create target folder
+            DirectoryInfo targetFolder = new DirectoryInfo(toPath);
+            if (!targetFolder.Exists)
+                targetFolder.Create();
+
+            // copy entries
+            foreach (FileSystemInfo entry in source.GetFileSystemInfos())
+            {
+                string targetName = Path.Combine(targetFolder.FullName, entry.Name);
+
+                switch (entry)
+                {
+                    case FileInfo sourceFile:
+                        sourceFile.CopyToAndWait(targetName);
+                        break;
+
+                    case DirectoryInfo sourceDir:
+                        sourceDir.RecursiveCopyTo(targetName);
+                        break;
+
+                    default:
+                        throw new NotSupportedException($"Unknown filesystem info type '{source.GetType().FullName}'.");
+                }
+            }
         }
     }
 }

--- a/SDV.Installer/Program.cs
+++ b/SDV.Installer/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using SDV.Installer.Framework;
 
@@ -12,37 +13,21 @@ namespace SDV.Installer
         ** Fields
         *********/
         private static readonly string ExePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-        private static readonly string CopyToGameFolderPath = Path.Combine(ExePath, "libs", "CopyToGameFolder");
+        private static readonly string CopyToGameFolderRelativePath = Path.Combine("libs", "CopyToGameFolder");
+        private static readonly string StagingPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
 
         private const string ExeName = "StardewValley.exe";
         private const string ModifiedExeName = "MONOMODDED_" + ExeName;
 
-        private static readonly string[] DirtyFiles = {
-            ExeName,
-            ModifiedExeName,
-            "MONOMODDED_StardewValley.pdb",
-        };
 
         /*********
         ** Public methods
         *********/
         public static void Main()
         {
-            Console.WriteLine("Cleaning out any potentially dirty files...");
-
-            foreach (string fileName in DirtyFiles)
-            {
-                FileInfo file = new FileInfo(Path.Combine(ExePath, fileName));
-                if (file.DeleteAndWait())
-                    Console.WriteLine($"Deleted {fileName}!");
-            }
-
-            for (int i = 0; i < 2; i++)
-                Console.WriteLine();
-
-            Console.WriteLine(" Welcome to the Stardew Valley 64bit patcher!");
-            Console.WriteLine("  Please note that this program requires a copy of the Linux version of Stardew Valley.");
-            Console.WriteLine("  You will have to install this manually through DepotDownloader.");
+            Console.WriteLine("Welcome to the Stardew Valley 64-bit patcher!");
+            Console.WriteLine(" Please note that this program requires a copy of the Linux version of Stardew Valley.");
+            Console.WriteLine(" You will have to install this manually through DepotDownloader.");
             Console.WriteLine();
             Prompt();
         }
@@ -53,8 +38,7 @@ namespace SDV.Installer
         *********/
         private static void Prompt()
         {
-            string option = WriteReadLine(" [1] I don't have a copy of the Linux version!" +
-                                          "\n [2] I'm good to go!");
+            string option = WriteReadLine("[1] I don't have a copy of the Linux version!\n[2] I'm good to go!");
 
             if (!int.TryParse(option, out int optionNum))
                 return;
@@ -82,23 +66,26 @@ namespace SDV.Installer
         {
             // TODO: Integrate this into this program... eventually?
             Console.WriteLine();
-            WriteReadKey(" Please download DepotDownloader through https://github.com/SteamRE/DepotDownloader" +
-                         "\n Press any key to exit...");
+            Console.WriteLine("Please download DepotDownloader through https://github.com/SteamRE/DepotDownloader");
+            WriteReadKey("Press any key to exit...");
         }
 
         private static void Continue()
         {
             Console.WriteLine();
 
-            string installationFolder = WriteReadLine("Please provide the location of the depot-downloaded copy of Stardew Valley:");
+            string installPath = WriteReadLine("Please provide the location of the depot-downloaded copy of Stardew Valley:");
             Console.WriteLine();
 
-            CopyRequiredDlls(installationFolder);
-            ApplyMonoModPatches(installationFolder);
+            DirectoryInfo installDir = new DirectoryInfo(installPath);
+            DirectoryInfo stagingDir = PrepareStagingFolder(installDir);
+            ApplyPatches(stagingDir);
+            InstallFiles(stagingDir, installDir);
 
-            Console.WriteLine();
-            WriteReadKey($" Installation complete! Please launch {ExeName} from the depot-download folder!" +
-                         "\n Press any key to exit...");
+            SetColor(ConsoleColor.Green, () =>
+                Console.WriteLine($"Installation complete! Please launch {ExeName} from the game folder.")
+            );
+            WriteReadKey("Press any key to exit...");
         }
 
         private static string WriteReadLine(string value)
@@ -113,106 +100,108 @@ namespace SDV.Installer
             Console.ReadKey();
         }
 
-        private static void CopyRequiredDlls(string installPath)
+        /// <summary>Create the staging folder with all the files needed to run the patcher.</summary>
+        /// <param name="installDir">The game install folder.</param>
+        private static DirectoryInfo PrepareStagingFolder(DirectoryInfo installDir)
         {
-            Console.WriteLine("Copying required DLLs over to the installation location:");
+            Console.WriteLine($"Copying files to temporary folder ({StagingPath})...");
+            var stagingDir = new DirectoryInfo(StagingPath);
 
-            // copy game DLLs into execution folder
-            foreach (FileInfo dll in new DirectoryInfo(installPath).GetFiles("*.dll"))
+            // copy installer files
+            new DirectoryInfo(ExePath).RecursiveCopyTo(stagingDir.FullName);
+
+            // copy game DLLs
+            foreach (FileInfo dll in installDir.GetFiles("*.dll"))
+                dll.CopyToAndWait(Path.Combine(stagingDir.FullName, dll.Name));
+
+            // copy game executable
             {
-                Console.WriteLine($" Copying {dll.Name} -> exec directory...");
-                dll.CopyToAndWait(Path.Combine(ExePath, dll.Name));
-            }
-
-            // copy files into game folder
-            foreach (FileInfo dll in new DirectoryInfo(CopyToGameFolderPath).GetFiles("*.dll"))
-            {
-                string dllName = dll.Name;
-
-                try
+                FileInfo file = installDir.GetFiles(ExeName).FirstOrDefault();
+                if (file == null)
                 {
-                    // TODO: Remove exec step
-                    Console.WriteLine($" Copying {dllName} -> exec directory...");
-                    dll.CopyToAndWait(Path.Combine(ExePath, dllName));
-
-                    Console.WriteLine($" Copying {dllName} -> SDV directory...");
-                    dll.CopyToAndWait(Path.Combine(installPath, dllName));
-                }
-                catch (DirectoryNotFoundException e)
-                {
-                    Console.WriteLine($"Could not locate directory: {e.Message}");
+                    Console.WriteLine($"Could not locate {ExeName}");
                     Console.WriteLine("Falling back to previous prompt...");
                     Continue();
                 }
+
+                file.CopyToAndWait(Path.Combine(stagingDir.FullName, ExeName));
             }
 
+            // copy overwrite files
+            foreach (FileInfo dll in new DirectoryInfo(Path.Combine(ExePath, CopyToGameFolderRelativePath)).GetFiles("*.dll"))
+                dll.CopyToAndWait(Path.Combine(stagingDir.FullName, dll.Name));
+
+            Console.WriteLine();
+            return stagingDir;
+        }
+
+        /// <summary>Patch the files in the staging folder.</summary>
+        /// <param name="stagingDir">The staging folder to patch.</param>
+        private static void ApplyPatches(DirectoryInfo stagingDir)
+        {
+            // apply MonoMod patches
+            Console.WriteLine("Applying MonoMod patches...");
+            RunCommand($"MonoMod.exe {ExeName}", workingPath: stagingDir.FullName);
+            Console.WriteLine();
+
+            // apply CorFlags
+            Console.WriteLine($"Patching {ModifiedExeName} flags with CorFlags... (If this doesn't work, please relaunch with administrator privileges.)");
+            RunCommand($"{Path.Combine("libs", "CorFlags.exe")} {ModifiedExeName} /32BITREQ-", workingPath: stagingDir.FullName);
             Console.WriteLine();
         }
 
-        private static void ApplyMonoModPatches(string installPath)
+        /// <summary>Copy the modified files into the game folder.</summary>
+        /// <param name="stagingDir">The staging folder which was patched.</param>
+        /// <param name="installDir">The game install folder.</param>
+        private static void InstallFiles(DirectoryInfo stagingDir, DirectoryInfo installDir)
         {
-            Console.WriteLine($"Copying over {ExeName} to patch...");
-
-            try
+            // copy override files
+            Console.WriteLine("Copying override files...");
+            DirectoryInfo overridesFolder = new DirectoryInfo(Path.Combine(stagingDir.FullName, CopyToGameFolderRelativePath));
+            foreach (FileInfo dll in overridesFolder.GetFiles("*.dll"))
             {
-                FileInfo file = new FileInfo(Path.Combine(installPath, ExeName));
-                file.CopyToAndWait(Path.Combine(ExePath, ExeName));
-            }
-            catch (FileNotFoundException e)
-            {
-                Console.WriteLine($"Could not locate file: {e.FileName}");
-                Console.WriteLine("Falling back to previous prompt...");
-                Continue();
+                string dllName = dll.Name;
+                dll.CopyToAndWait(Path.Combine(installDir.FullName, dllName));
             }
 
-            Console.WriteLine("Applying MonoMod patches...");
-
-            RunCommand($"MonoMod.exe {ExeName}");
-
-            while (true)
-            {
-                try
-                {
-                    Console.WriteLine($"Modifying {ModifiedExeName} flags with CorFlags...\n(If this does not work, please re-launch with administrator privileges)");
-
-                    RunCommand($"libs\\CorFlags.exe {ModifiedExeName} /32BITREQ-");
-
-                    Console.WriteLine("Copying the modified EXE over to the installation location...");
-
-                    var file = new FileInfo(Path.Combine(ExePath, ModifiedExeName));
-                    file.CopyToAndWait(Path.Combine(installPath, ExeName));
-                    break;
-                }
-                catch (FileNotFoundException)
-                {
-                    Console.WriteLine("File not found... retrying...");
-                }
-            }
-
-            Console.WriteLine("Copied the modified EXE over to the installation location!");
+            // copy modified executable
+            Console.WriteLine("Copying patched executable...");
+            var file = new FileInfo(Path.Combine(stagingDir.FullName, ModifiedExeName));
+            file.CopyToAndWait(Path.Combine(installDir.FullName, ExeName));
+            Console.WriteLine();
         }
 
         /// <summary>Run a command through <c>cmd.exe</c> and wait for it to finish.</summary>
         /// <param name="command">The command to run.</param>
-        private static void RunCommand(string command)
+        /// <param name="workingPath">The absolute path to the working directory for the command, if any.</param>
+        private static void RunCommand(string command, string workingPath = null)
         {
-            Console.ForegroundColor = ConsoleColor.DarkGray;
-
-            try
+            SetColor(ConsoleColor.DarkGray, () =>
             {
-                var process = new Process
+                var startInfo = new ProcessStartInfo
                 {
-                    StartInfo = new ProcessStartInfo
-                    {
-                        FileName = "cmd.exe",
-                        Arguments = $"/C {command}",
-
-                        // run within the same window
-                        UseShellExecute = false
-                    }
+                    FileName = "cmd.exe",
+                    Arguments = $"/C {command}",
+                    UseShellExecute = false // run within the same window
                 };
+                if (workingPath != null)
+                    startInfo.WorkingDirectory = workingPath;
+
+                var process = new Process { StartInfo = startInfo };
                 process.Start();
                 process.WaitForExit();
+            });
+        }
+
+        /// <summary>Write text with a given console color.</summary>
+        /// <param name="color">The color to set.</param>
+        /// <param name="action">The action which writes console text.</param>
+        private static void SetColor(ConsoleColor color, Action action)
+        {
+            Console.ForegroundColor = color;
+            try
+            {
+                action();
             }
             finally
             {


### PR DESCRIPTION
The installer now writes files to a temporary staging folder. That simplifies troubleshooting, avoids changing the installer itself, and avoids copying files from one run to the next.