### PR TITLE
Fix asset name normalization in MonoGame

### DIFF
--- a/SDV.Installer/Program.cs
+++ b/SDV.Installer/Program.cs
@@ -19,6 +19,9 @@ namespace SDV.Installer
         private const string ExeName = "StardewValley.exe";
         private const string ModifiedExeName = "MONOMODDED_" + ExeName;
 
+        private const string MonoGameDllName = "MonoGame.Framework.dll";
+        private const string ModifiedMonoGameDllName = "MONOMODDED_" + MonoGameDllName;
+
 
         /*********
         ** Public methods
@@ -140,8 +143,10 @@ namespace SDV.Installer
         private static void ApplyPatches(DirectoryInfo stagingDir)
         {
             // apply MonoMod patches
-            Console.WriteLine("Applying MonoMod patches...");
+            Console.WriteLine($"Applying MonoMod patches to {ExeName}...");
             RunCommand($"MonoMod.exe {ExeName}", workingPath: stagingDir.FullName);
+            Console.WriteLine($"Applying MonoMod patches to {MonoGameDllName}...");
+            RunCommand($"MonoMod.exe {MonoGameDllName}", workingPath: stagingDir.FullName);
             Console.WriteLine();
 
             // apply CorFlags
@@ -165,9 +170,19 @@ namespace SDV.Installer
             }
 
             // copy modified executable
-            Console.WriteLine("Copying patched executable...");
-            var file = new FileInfo(Path.Combine(stagingDir.FullName, ModifiedExeName));
-            file.CopyToAndWait(Path.Combine(installDir.FullName, ExeName));
+            Console.WriteLine($"Copying patched {ExeName}...");
+            {
+                var file = new FileInfo(Path.Combine(stagingDir.FullName, ModifiedExeName));
+                file.CopyToAndWait(Path.Combine(installDir.FullName, ExeName));
+            }
+
+            // copy modified MonoGame
+            Console.WriteLine($"Copying patched {MonoGameDllName}...");
+            {
+                var file = new FileInfo(Path.Combine(stagingDir.FullName, ModifiedMonoGameDllName));
+                file.CopyToAndWait(Path.Combine(installDir.FullName, MonoGameDllName));
+            }
+
             Console.WriteLine();
         }
 

--- a/StardewValley.Patches.mm/Framework/PatchHelper.cs
+++ b/StardewValley.Patches.mm/Framework/PatchHelper.cs
@@ -21,7 +21,7 @@ namespace StardewValley.Patches.mm.Framework
         /// <param name="name">The event name.</param>
         public static EventInfo RequireEvent(Type type, string name)
         {
-            return type.GetEvent(name, PatchHelper.All) ?? throw new InvalidOperationException($"Can't find event '{name}' on {type.FullName}");
+            return type.GetEvent(name, PatchHelper.All) ?? throw new InvalidOperationException($"Can't find event '{name}' on {type.FullName}.");
         }
 
         /// <summary>Get a field and assert that it's present.</summary>
@@ -29,23 +29,30 @@ namespace StardewValley.Patches.mm.Framework
         /// <param name="name">The field name.</param>
         public static FieldInfo RequireField(Type type, string name)
         {
-            return type.GetField(name, PatchHelper.All) ?? throw new InvalidOperationException($"Can't find field '{name}' on {type.FullName}");
+            return type.GetField(name, PatchHelper.All) ?? throw new InvalidOperationException($"Can't find field '{name}' on {type.FullName}.");
         }
 
-        /// <summary>Get a method from the underlying <see cref="KeyboardInput"/> and assert that it's present.</summary>
+        /// <summary>Get a method and assert that it's present.</summary>
         /// <param name="type">The type whose members to search.</param>
         /// <param name="name">The method name.</param>
         public static MethodInfo RequireMethod(Type type, string name)
         {
-            return type.GetMethod(name, PatchHelper.All) ?? throw new InvalidOperationException($"Can't find method '{name}' on {type.FullName}");
+            return type.GetMethod(name, PatchHelper.All) ?? throw new InvalidOperationException($"Can't find method '{name}' on {type.FullName}.");
         }
 
-        /// <summary>Get a nested type from the underlying <see cref="KeyboardInput"/> and assert that it's present.</summary>
+        /// <summary>Get a type and assert that it's present.</summary>
+        /// <param name="name">The type and assembly name.</param>
+        public static Type RequireType(string name)
+        {
+            return Type.GetType(name, throwOnError: false) ?? throw new InvalidOperationException($"Can't find type '{name}'.");
+        }
+
+        /// <summary>Get a nested type and assert that it's present.</summary>
         /// <param name="type">The type whose members to search.</param>
         /// <param name="name">The nested type name.</param>
         public static Type RequireNestedType(Type type, string name)
         {
-            return type.GetNestedType(name, PatchHelper.All) ?? throw new InvalidOperationException($"Can't find nested type '{name}' on {type.FullName}");
+            return type.GetNestedType(name, PatchHelper.All) ?? throw new InvalidOperationException($"Can't find nested type '{name}' on {type.FullName}.");
         }
     }
 }

--- a/StardewValley.Patches.mm/Patches/MonoGame/patch_ContentManager.cs
+++ b/StardewValley.Patches.mm/Patches/MonoGame/patch_ContentManager.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.Xna.Framework.Content;
+using StardewValley.Patches.mm.Framework;
+
+// ReSharper disable once CheckNamespace
+namespace StardewValley
+{
+    /// <summary>A MonoMod patch that reimplements <see cref="ContentManager.Load{T}"/> to normalize assets in the Windows format.</summary>
+    class patch_ContentManager : ContentManager
+    {
+        /// <inheritdoc />
+        public patch_ContentManager(IServiceProvider serviceProvider)
+            : base(serviceProvider) { }
+
+        /// <inheritdoc />
+        public patch_ContentManager(IServiceProvider serviceProvider, string rootDirectory)
+            : base(serviceProvider, rootDirectory) { }
+
+        /// <inheritdoc />
+        public override T Load<T>(string assetName)
+        {
+            // get private fields
+            bool disposed = (bool)PatchHelper.RequireField(typeof(ContentManager), "disposed").GetValue(this);
+            var loadedAssets = (Dictionary<string, object>)PatchHelper.RequireField(typeof(ContentManager), "loadedAssets").GetValue(this);
+
+            // replicate game logic
+            if (string.IsNullOrEmpty(assetName))
+                throw new ArgumentNullException(nameof(assetName));
+            if (disposed)
+                throw new ObjectDisposedException(nameof(ContentManager));
+
+            // change key normalization
+            string key;
+            {
+                Type type = PatchHelper.RequireType("StardewModdingAPI.Utilities.PathUtilities, StardewModdingAPI");
+                MethodInfo method = PatchHelper.RequireMethod(type, "NormalizePath");
+                key = (string)method.Invoke(null, new object[] { assetName });
+            }
+
+            // replicate game logic
+            if (loadedAssets.TryGetValue(key, out var value) && value is T result)
+                return result;
+            T val = this.ReadAsset<T>(assetName, null);
+            loadedAssets[key] = val;
+            return val;
+        }
+    }
+}

--- a/StardewValley.Patches.mm/Patches/StardewValley/patch_KeyboardDispatcher.cs
+++ b/StardewValley.Patches.mm/Patches/StardewValley/patch_KeyboardDispatcher.cs
@@ -12,6 +12,7 @@ using StardewValley.Patches.mm.Framework;
 namespace StardewValley
 {
     // ReSharper disable once ArrangeTypeModifiers
+    /// <summary>A MonoMod patch that reimplements the <see cref="KeyboardDispatcher"/> constructor to remove a Linux-only check around the <see cref="GameWindow.TextInput"/> event set, ensures that <see cref="KeyboardInput.Initialize"/> is called, and removes the unneeded <see cref="KeyboardInput.CharEntered"/> and <see cref="KeyboardInput.KeyDown"/> events.</summary>
     [SuppressMessage("Style", "IDE1006:Naming Styles")]
     class patch_KeyboardDispatcher : KeyboardDispatcher
     {

--- a/StardewValley.Patches.mm/Patches/StardewValley/patch_KeyboardInput.cs
+++ b/StardewValley.Patches.mm/Patches/StardewValley/patch_KeyboardInput.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Xna.Framework;
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Microsoft.Xna.Framework;
 using StardewValley.Patches.mm.Framework;
 
 // ReSharper disable once CheckNamespace


### PR DESCRIPTION
The Linux version of MonoGame is hardcoded to normalize asset names to Linux-style forward slashes, but SMAPI/mods assume Windows-style backslashes on Windows. This commit changes MonoGame to normalize Windows-style.