### PR TITLE
Allow patching more than once, add version field, improve error-handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,13 @@ open (or you can contact me directly beforehand).
 
 All contributors are credited in the release notes.
 
+### Preparing a release
+To prepare a release build:
+
+1. Update `common.targets`, `RELEASE-NOTES.md`, and `Stardew64Installer.Framework/Constants` for the new version.
+2. Build the solution in Release mode.
+3. Zip the contents of `Stardew64Installer/bin/Release/net452` into a file like `Stardew64Installer 1.2.2.zip`.
+4. Upload or share that file.
+
 ## See also
 * [Release notes](RELEASE-NOTES.md)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,7 @@
 ﻿← [README](README.md)
 
 ## Upcoming release
+* Added support for patching the same game folder more than once (thanks to Pathoschild!).
 * Improved error-handling for game path (thanks to Pathoschild!).
 * Fixed issue where a failed install would ask for a new game path, install to that folder, then try to resume the previous failed install (thanks to Pathoschild!).
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,12 @@
 ﻿← [README](README.md)
 
+## Upcoming release
+* Improved error-handling for game path (thanks to Pathoschild!).
+* Fixed issue where a failed install would ask for a new game path, install to that folder, then try to resume the previous failed install (thanks to Pathoschild!).
+
 ## 1.1.2
+Released 03 April 2021.
+
 * Fixed `MonoGame.Framework` patches not being applied (thanks to Pathoschild!).
 * Internal refactoring (thanks to Pathoschild!).
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,7 @@
 
 ## Upcoming release
 * Added support for patching the same game folder more than once (thanks to Pathoschild!).
+* Added `Game1.Stardew64InstallerVersion` field so SMAPI can log the patch tool version (thanks to Pathoschild!).
 * Improved error-handling for game path (thanks to Pathoschild!).
 * Fixed issue where a failed install would ask for a new game path, install to that folder, then try to resume the previous failed install (thanks to Pathoschild!).
 

--- a/Stardew64Installer.Framework/Constants.cs
+++ b/Stardew64Installer.Framework/Constants.cs
@@ -1,0 +1,9 @@
+﻿namespace Stardew64Installer.Framework
+{
+    /// <summary>Provides constants available to SMAPI.</summary>
+    public static class Constants
+    {
+        /// <summary>The version of this patch tool.</summary>
+        public static string Stardew64InstallerVersion { get; } = "1.1.2";
+    }
+}

--- a/Stardew64Installer.Framework/Stardew64Installer.Framework.projitems
+++ b/Stardew64Installer.Framework/Stardew64Installer.Framework.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Stardew64Installer.Framework</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Constants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FileUtilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PatchHelper.cs" />
   </ItemGroup>

--- a/StardewValley.Patches.mm/Game1Patches.cs
+++ b/StardewValley.Patches.mm/Game1Patches.cs
@@ -1,0 +1,13 @@
+﻿using MonoMod;
+using Stardew64Installer.Framework;
+
+namespace Stardew64Installer.Patches.StardewValley
+{
+    /// <summary>A MonoMod patch that adds a patch version field.</summary>
+    [MonoModPatch("global::StardewValley.Game1")]
+    internal static class Game1Patches
+    {
+        /// <summary>The version of this patch tool.</summary>
+        public static string Stardew64InstallerVersion => Constants.Stardew64InstallerVersion;
+    }
+}

--- a/common.targets
+++ b/common.targets
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <Version>1.1.2</Version>
     <TargetFramework>net452</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This pull request...

* Adds support for patching the same game folder more than once.
* Adds a `Game1.Stardew64InstallerVersion` field, so SMAPI can log the patch tool version.
* Improves error-handling for the game path.
* Fixes an issue where a failed install would ask for a new game path, install to that folder, then try to resume the previous failed install.